### PR TITLE
fix: delete yarn installing as it already contained in the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,5 @@ RUN curl -SLO "https://github.com/jgm/pandoc/releases/download/$PANDOC_VERSION/p
   && rm pandoc-$PANDOC_VERSION-1-amd64.deb
 
 ENV NPM_CONFIG_LOGLEVEL warn
-RUN npm install -g yarn
 
 


### PR DESCRIPTION
```
Step 12/12 : RUN npm install -g yarn
 ---> Running in 711b660dd2c0
npm ERR! code EEXIST
npm ERR! syscall symlink
npm ERR! path ../lib/node_modules/yarn/bin/yarn.js
npm ERR! dest /usr/local/bin/yarn
npm ERR! errno -17
npm ERR! EEXIST: file already exists, symlink '../lib/node_modules/yarn/bin/yarn.js' -> '/usr/local/bin/yarn'
npm ERR! File exists: /usr/local/bin/yarn
npm ERR! Remove the existing file and try again, or run npm
npm ERR! with --force to overwrite files recklessly.
```